### PR TITLE
ci(desktop): adiciona script npm "tauri" para o tauri-action

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"
   },


### PR DESCRIPTION
O workflow Build & Release falhava com:
  npm error Missing script: "tauri"

O tauri-apps/tauri-action invoca "npm run tauri -- build --target ...", mas só existiam aliases "tauri:dev" e "tauri:build". Adicionado o script genérico "tauri" -> "tauri" para o action conseguir passar argumentos arbitrários (--target universal-apple-darwin, etc.).


O `tauri-apps/tauri-action` invoca `npm run tauri -- build --target ...` internamente, mas em `apps/desktop/package.json` só existiam aliases específicos `tauri:dev` e `tauri:build`.

## O que foi feito

- Adicionado script genérico `"tauri": "tauri"` em `apps/desktop/package.json` para o action conseguir passar argumentos arbitrários (`--target universal-apple-darwin`, etc.).

## Resultado esperado

- `Build & Release` passa nas duas plataformas (macOS universal + Windows).
- Próximo push de tag `v*` cria release draft com bundles anexados.

## Como validar

- [ ] `Actions → Build & Release → Run workflow` → completar sem erro de "Missing script: tauri".
- [ ] Bundles aparecem nos artifacts (`.dmg` no Mac, `.msi`/`.exe` no Windows).